### PR TITLE
Add a tox environment to test with oldest version of dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,6 @@ jobs:
     - name: Run tests with CASA
       if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
       run: tox -v -e test-casa
-    - name: Run tests with CASA (and latest developer version of dependencies)
-      if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
-      run: tox -v -e test-casa-devdeps
     - name: Run tests with CASA (and oldest version of dependencies)
       if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
       run: tox -v -e test-casa-oldestdeps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,14 @@ jobs:
     - name: Run tests with latest stable version of dependencies
       if: ${{ matrix.python-version != '3.9' }}
       run: tox -v -e test
+    - name: Run tests with latest developer version of dependencies
+      if: ${{ matrix.python-version == '3.9' }}
+      run: tox -v -e test-devdeps
     - name: Run tests with CASA
       if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
       run: tox -v -e test-casa
     - name: Run tests with CASA (and latest developer version of dependencies)
-      if: ${{ matrix.python-version == '3.9' }}
+      if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
       run: tox -v -e test-casa-devdeps
     - name: Run tests with CASA (and oldest version of dependencies)
       if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,15 @@ jobs:
     - name: Run tests with latest stable version of dependencies
       if: ${{ matrix.python-version != '3.9' }}
       run: tox -v -e test
-    - name: Run tests with latest developer version of dependencies
-      if: ${{ matrix.python-version == '3.9' }}
-      run: tox -v -e test-dev
     - name: Run tests with CASA
       if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
       run: tox -v -e test-casa
+    - name: Run tests with CASA (and latest developer version of dependencies)
+      if: ${{ matrix.python-version == '3.9' }}
+      run: tox -v -e test-casa-devdeps
+    - name: Run tests with CASA (and oldest version of dependencies)
+      if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04' }}
+      run: tox -v -e test-casa-oldestdeps
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1.0.13
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ zip_safe = False
 packages = find:
 install_requires =
     astropy>=4.0
-    numpy>=1.16
+    numpy>=1.17
     dask[array]>=1.0
 python_requires = >=3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-dev,-casa}
+    py{36,37,38}-test{,-oldestdeps,-devdeps,-casa}
     build_docs
     codestyle
 requires =
@@ -24,9 +24,12 @@ changedir =
 description =
     run tests with pytest
 deps =
-    dev: :NUMPY_NIGHTLY:numpy
-    dev: pyerfa
-    dev: :ASTROPY_NIGHTLY:astropy
+    oldestdeps: astropy==4.0.*
+    oldestdeps: numpy==1.17.*
+    oldestdeps: dask[array]==1.0.*
+    devdeps: :NUMPY_NIGHTLY:numpy
+    devdeps: pyerfa
+    devdeps: :ASTROPY_NIGHTLY:astropy
     casa: :NRAO:casatools
     casa: :NRAO:casatasks
 extras =


### PR DESCRIPTION
This made me realize that our minimum supported Numpy is actually 1.17