### PR TITLE
Expand tests to all casadata tables

### DIFF
--- a/casa_formats_io/casa_dask.py
+++ b/casa_formats_io/casa_dask.py
@@ -233,7 +233,7 @@ def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None):
                     chunkoversample = previous_chunkoversample
                     finished = True
                     break
-                previous_chunkoversample = chunkoversample
+                previous_chunkoversample = chunkoversample.copy()
             if finished:
                 break
 

--- a/casa_formats_io/casa_dask.py
+++ b/casa_formats_io/casa_dask.py
@@ -118,7 +118,7 @@ class CASAArrayWrapper:
                     .reshape(self._chunkshape[::-1], order='F').T[item_in_chunk])
 
 
-def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None, seqnr=0, dm=None, is_mask=None):
+def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None):
     """
     Read a CASA image (a folder containing a ``table.f0_TSM0`` file) into a
     dask array.
@@ -144,24 +144,18 @@ def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None, seq
             mask = 'mask0'
         imagename = os.path.join(str(imagename), mask)
 
-    if is_mask:
-        mask = True
-
     if not os.path.exists(imagename):
         raise FileNotFoundError(imagename)
 
     # the data is stored in the following binary file
     # each of the chunks is stored on disk in fortran-order
+    img_fn = os.path.join(str(imagename), 'table.f0_TSM0')
 
-    img_fn = os.path.join(str(imagename), f'table.f{seqnr}_TSM0')
+    # load the metadata from the image table.
+    table = Table.read(str(imagename), endian='>')
 
-    if dm is None:
-
-        # load the metadata from the image table.
-        table = Table.read(str(imagename), endian='>')
-
-        # extract data manager
-        dm = table.column_set.data_managers[0]
+    # extract data manager
+    dm = table.column_set.data_managers[0]
 
     # Determine whether file is big endian
     big_endian = dm.big_endian

--- a/casa_formats_io/casa_dask.py
+++ b/casa_formats_io/casa_dask.py
@@ -118,7 +118,7 @@ class CASAArrayWrapper:
                     .reshape(self._chunkshape[::-1], order='F').T[item_in_chunk])
 
 
-def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None):
+def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None, seqnr=0, dm=None, is_mask=None):
     """
     Read a CASA image (a folder containing a ``table.f0_TSM0`` file) into a
     dask array.
@@ -144,18 +144,24 @@ def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None):
             mask = 'mask0'
         imagename = os.path.join(str(imagename), mask)
 
+    if is_mask:
+        mask = True
+
     if not os.path.exists(imagename):
         raise FileNotFoundError(imagename)
 
     # the data is stored in the following binary file
     # each of the chunks is stored on disk in fortran-order
-    img_fn = os.path.join(str(imagename), 'table.f0_TSM0')
 
-    # load the metadata from the image table.
-    table = Table.read(str(imagename), endian='>')
+    img_fn = os.path.join(str(imagename), f'table.f{seqnr}_TSM0')
 
-    # extract data manager
-    dm = table.column_set.data_managers[0]
+    if dm is None:
+
+        # load the metadata from the image table.
+        table = Table.read(str(imagename), endian='>')
+
+        # extract data manager
+        dm = table.column_set.data_managers[0]
 
     # Determine whether file is big endian
     big_endian = dm.big_endian

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -899,6 +899,11 @@ class TiledCellStMan(TiledStMan):
 
         super().read_header(f)
 
+    def read_column(self, filename, seqnr, column, coldesc, colindex_in_dm):
+        from .casa_dask import image_to_dask
+        array = image_to_dask(filename, seqnr=seqnr, dm=self, is_mask=coldesc.value_type == 'bool')
+        return array.compute().reshape((1,) + array.shape)
+
 
 class TiledShapeStMan(TiledStMan):
 

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -184,7 +184,7 @@ def read_as_numpy_array(f, value_type, nelem, shape=None):
     Read the next 'nelem' values as a Numpy array
     """
     if value_type == 'string':
-        array = np.array([read_string(f) for i in range(nelem)], dtype='<U16')
+        array = np.array([read_string(f) for i in range(nelem)])
     elif value_type == 'bool':
         array = np.unpackbits(np.frombuffer(f.read(int(np.ceil(nelem / 8)) * 8), dtype='uint8'), bitorder='little').astype(bool)[:nelem]
     elif value_type in TO_DTYPE:
@@ -406,7 +406,7 @@ class Table(BaseCasaObject):
                 if coldata is not None:
                     tbl[colname] = coldata
             else:
-                pass
+                warnings.warn(f'Skipping column {colname} with data manager {dm.__class__.__name__}')
 
         return tbl
 
@@ -914,6 +914,26 @@ class TiledShapeStMan(TiledStMan):
         # super().read_header(f)
 
 
+
+class StManColumnAipsIO(BaseCasaObject):
+
+    @classmethod
+    def read(cls, f, value_type):
+        self = cls()
+        read_int32(f)
+        version = check_type_and_version(f, 'StManColumnAipsIO', 2)
+        self.nr = read_int32(f)
+        irow = 0
+        self.values = []
+        while irow < self.nr:
+            nr = read_int32(f)
+            nr = read_int32(f)
+            self.values.append(read_as_numpy_array(f, value_type, nr))
+            irow += nr
+        self.values = np.hstack(self.values)
+        return self
+
+
 class StManAipsIO(BaseCasaObject):
 
     @classmethod
@@ -924,7 +944,18 @@ class StManAipsIO(BaseCasaObject):
 
     @with_nbytes_prefix
     def read_header(self, f):
-        check_type_and_version(f, 'StManAipsIO', 2)
+        version = check_type_and_version(f, 'StManAipsIO', 2)
+        if version > 1:
+            self.name = read_string(f)
+        self.seqnr = read_int32(f)
+        self.unique_number = read_int32(f)
+        self.nrow = read_int32(f)
+        self.ncol = read_int32(f)
+        self.value_types = [TYPES[read_int32(f)] for icol in range(self.ncol)]
+        self.columns = [StManColumnAipsIO.read(f, self.value_types[icol]) for icol in range(self.ncol)]
+
+    def read_column(self, filename, seqnr, column, coldesc, colindex_in_dm):
+        return self.columns[colindex_in_dm].values
 
 
 class TiledColumnStMan(TiledStMan):

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -989,7 +989,7 @@ class TiledCellStMan(TiledStMan):
                         chunkoversample = previous_chunkoversample
                         finished = True
                         break
-                    previous_chunkoversample = chunkoversample
+                    previous_chunkoversample = chunkoversample.copy()
                 if finished:
                     break
 

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -639,6 +639,7 @@ class StandardStMan(BaseCasaObject):
                     data.append(np.fromstring(f.read(coldesc.maxlen * rows_in_bucket[bucket_id]), dtype=f'S{coldesc.maxlen}'))
             elif coldesc.value_type == 'record':
                 # TODO: determine how to handle this properly
+                warnings.warn(f'Skipping column {coldesc.name} with type record')
                 data = None
             else:
                 if coldesc.is_direct or 'Scalar' in coldesc.stype:

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -543,7 +543,8 @@ class StandardStMan(BaseCasaObject):
                 return next_variable_string_buckets[vs_bucket_id]
             pos = f.tell()
             f.seek(512 + self.bucket_size * vs_bucket_id + 12)
-            next_vs_bucket_id = read_int32(f)
+            # For some reason, the next bucket index is stored in big endian
+            next_vs_bucket_id = bytes_to_int32(f.read(4), '>')
             variable_string_buckets[vs_bucket_id] = f.read(self.bucket_size - 16)
             next_variable_string_buckets[vs_bucket_id] = next_vs_bucket_id
             f.seek(pos)

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -643,7 +643,7 @@ class StandardStMan(BaseCasaObject):
                 data = None
             else:
                 if coldesc.is_direct or 'Scalar' in coldesc.stype:
-                    data.append(read_as_numpy_array(f, coldesc.value_type, rows_in_bucket[bucket_id] * nelements, shape=(-1,) + shape))
+                    data.append(read_as_numpy_array(f, coldesc.value_type, rows_in_bucket[bucket_id] * nelements, shape=(-1,) + shape[::-1]))
                 else:
                     values = []
                     for irow in range(rows_in_bucket[bucket_id]):

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -185,6 +185,9 @@ def read_as_numpy_array(f, value_type, nelem, shape=None):
     """
     if value_type == 'string':
         array = np.array([read_string(f) for i in range(nelem)])
+        if nelem > 0:
+            if max([len(s) for s in array]) < 16:  # HACK: only needed for getdesc comparisons
+                array = array.astype('<U16')
     elif value_type == 'bool':
         array = np.unpackbits(np.frombuffer(f.read(int(np.ceil(nelem / 8)) * 8), dtype='uint8'), bitorder='little').astype(bool)[:nelem]
     elif value_type in TO_DTYPE:

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -156,7 +156,7 @@ def read_complex128(f):
 
 def read_string(f, length_modifier=0):
     value = read_int32(f) + length_modifier
-    return f.read(int(value)).decode('ascii')
+    return f.read(int(value)).replace(b'\x00', b'').decode('ascii')
 
 
 @with_nbytes_prefix

--- a/casa_formats_io/casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io.py
@@ -40,7 +40,7 @@ def _peek_no_prefix(f, length):
 class BaseCasaObject:
     def __repr__(self):
         from pprint import pformat
-        return f'{self.__class__.__name__}' + str(self.__dict__)
+        return f'{self.__class__.__name__}' + pformat(self.__dict__)
 
 
 class EndianAwareFileHandle:
@@ -75,8 +75,6 @@ def with_nbytes_prefix(func):
         if nbytes == 0:
             return
         bytes = f.read(nbytes - 4)
-        # if len(bytes) < nbytes - 4:
-        #     bytes += b'\x00' * (nbytes - 4 - len(bytes))
         b = EndianAwareFileHandle(BytesIO(bytes), f.endian, f.original_filename)
         if self:
             result = func(self, b, *args)

--- a/casa_formats_io/tests/test_casa_dask.py
+++ b/casa_formats_io/tests/test_casa_dask.py
@@ -141,10 +141,10 @@ def test_target_chunksize():
     ia.close()
 
     array1 = image_to_dask('large.image')
-    assert array1.chunksize == (256, 256, 256)
+    assert array1.chunksize == (128, 256, 256)
 
     array2 = image_to_dask('large.image', target_chunksize=100000)
-    assert array2.chunksize == (32, 32, 128)
+    assert array2.chunksize == (32, 32, 64)
 
     array3 = image_to_dask('large.image', target_chunksize=1000)
     assert array3.chunksize == (32, 32, 32)

--- a/casa_formats_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/tests/test_casa_low_level_io.py
@@ -292,17 +292,7 @@ else:
 
 EXPECTED_FAILURES = [
     'ephemerides/Sources',
-    'nrao/VLA/CalModels/3C123_P.im',
-    'nrao/VLA/CalModels/3C380_P.im',
-    'nrao/VLA/CalModels/3C138_P.im',
-    'nrao/VLA/CalModels/3C196_P.im',
-    'nrao/VLA/CalModels/3C48_P.im',
-    'nrao/VLA/CalModels/3C295_P.im',
-    'nrao/VLA/CalModels/3C286_P.im',
-    'nrao/VLA/CalModels/3C147_P.im',
     'nrao/VLA/GainCurves',
-    'nrao/VLA/standards/fluxcalibrator.data',
-    'gui/colormaps/default.tbl'
 ]
 
 
@@ -320,9 +310,21 @@ def test_casadata(table_filename):
         tb = table()
         tb.open(table_filename)
 
-        assert tt.colnames == tb.colnames()
+        expected_colnames = tb.colnames()
 
-        for colname in tt.colnames:
-            assert_equal(tt[colname], tb.getcol(colname).T)
+        # Some tables contain a Spectral_Record column that we can't read yet
+        # but that browsetable also can't read/display so we don't support this.
+        if 'Spectral_Record' in expected_colnames:
+            expected_colnames.remove('Spectral_Record')
+
+        assert tt.colnames == expected_colnames
+
+        for colname in expected_colnames:
+            try:
+                expected_data = tb.getcol(colname).T
+            except Exception:
+                # If casa can't read it, we can assume we don't need to support it
+                continue
+            assert_equal(tt[colname], expected_data)
 
         tb.close()

--- a/casa_formats_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/tests/test_casa_low_level_io.py
@@ -289,6 +289,7 @@ else:
     CASADATA_TABLES = [os.path.dirname(x) for x in glob.glob(os.path.join(datapath, '**', 'table.dat'), recursive=True)]
     CASADATA_INSTALLED = False
 
+
 @pytest.mark.parametrize('table_filename', CASADATA_TABLES)
 def test_casadata(table_filename):
 
@@ -303,7 +304,6 @@ def test_casadata(table_filename):
         assert tt.colnames == tb.colnames()
 
         for colname in tt.colnames:
-            print(colname)
             assert_equal(tt[colname], tb.getcol(colname).T)
 
         tb.close()

--- a/casa_formats_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/tests/test_casa_low_level_io.py
@@ -290,8 +290,27 @@ else:
     CASADATA_INSTALLED = False
 
 
+EXPECTED_FAILURES = [
+    'ephemerides/Sources',
+    'nrao/VLA/CalModels/3C123_P.im',
+    'nrao/VLA/CalModels/3C380_P.im',
+    'nrao/VLA/CalModels/3C138_P.im',
+    'nrao/VLA/CalModels/3C196_P.im',
+    'nrao/VLA/CalModels/3C48_P.im',
+    'nrao/VLA/CalModels/3C295_P.im',
+    'nrao/VLA/CalModels/3C286_P.im',
+    'nrao/VLA/CalModels/3C147_P.im',
+    'nrao/VLA/GainCurves',
+    'nrao/VLA/standards/fluxcalibrator.data',
+    'gui/colormaps/default.tbl'
+]
+
+
 @pytest.mark.parametrize('table_filename', CASADATA_TABLES)
 def test_casadata(table_filename):
+
+    if os.path.relpath(table_filename, datapath) in EXPECTED_FAILURES:
+        pytest.xfail()
 
     t = Table.read(table_filename, endian='<')
     tt = t.read_as_astropy_table()

--- a/casa_formats_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/tests/test_casa_low_level_io.py
@@ -291,8 +291,7 @@ else:
 
 
 EXPECTED_FAILURES = [
-    'ephemerides/Sources',
-    'nrao/VLA/GainCurves',
+    'ephemerides/Sources',  # our table is too long
 ]
 
 

--- a/casa_formats_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/tests/test_casa_low_level_io.py
@@ -286,8 +286,7 @@ except ImportError:
     CASADATA_TABLES = []
     CASADATA_INSTALLED = True
 else:
-    # TODO: In future we can include more of the tables in the testing
-    CASADATA_TABLES = [os.path.dirname(x) for x in glob.glob(os.path.join(datapath, 'geodetic', 'IERS*', 'table.dat'), recursive=True)]
+    CASADATA_TABLES = [os.path.dirname(x) for x in glob.glob(os.path.join(datapath, '**', 'table.dat'), recursive=True)]
     CASADATA_INSTALLED = False
 
 @pytest.mark.parametrize('table_filename', CASADATA_TABLES)


### PR DESCRIPTION
Still a work in progress but this expands the tests to all tables in the casadata package and fixes a number of issues and implements missing features. At the time of opening this PR:

```
=== 57 failed, 399 passed, 1 xfailed, 168 warnings in 49.70s ===
```

So getting close! A number of the failures are for the same reason so I think realistically there are 5-6 separate issues that need fixing here.