### PR TITLE
Group tables by DATA_DESC_ID when present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Fix bug that occurred when target_chunksize was smaller than the native
   CASA chunk size. [#10]
 
-- Started implementing a generic CASA table reader. [#12, #14, #15, #22]
+- Started implementing a generic CASA table reader. [#12, #14, #15, #22, #32]
 
 0.1 (2020-11-08)
 ----------------

--- a/casa_formats_io/__init__.py
+++ b/casa_formats_io/__init__.py
@@ -1,3 +1,11 @@
+# For convenience, we import the astropy Table class here which
+# allows one to do:
+#     >>> from casa_formats_io import Table
+# instead of:
+#     >>> import casa_formats_io
+#     >>> from astropy.table import Table
+from astropy.table import Table  # noqa
+
 from .casa_dask import *  # noqa
 from .casa_low_level_io import *  # noqa
 from .casa_wcs import *  # noqa

--- a/casa_formats_io/__init__.py
+++ b/casa_formats_io/__init__.py
@@ -2,3 +2,4 @@ from .casa_dask import *  # noqa
 from .casa_low_level_io import *  # noqa
 from .casa_wcs import *  # noqa
 from .version import version as __version__
+from . import table_reader

--- a/casa_formats_io/casa_dask.py
+++ b/casa_formats_io/casa_dask.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import dask.array
 
-from .casa_low_level_io import Table
+from .casa_low_level_io.table import CASATable
 from ._casa_chunking import _combine_chunks
 
 __all__ = ['image_to_dask']
@@ -153,7 +153,7 @@ def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None):
     img_fn = os.path.join(str(imagename), 'table.f0_TSM0')
 
     # load the metadata from the image table.
-    table = Table.read(str(imagename), endian='>')
+    table = CASATable.read(str(imagename), endian='>')
 
     # extract data manager
     dm = table.column_set.data_managers[0]

--- a/casa_formats_io/casa_low_level_io/__init__.py
+++ b/casa_formats_io/casa_low_level_io/__init__.py
@@ -1,2 +1,2 @@
 from .casa_functions import getdminfo, getdesc  # noqa
-from .table import Table  # noqa
+from . import table

--- a/casa_formats_io/casa_low_level_io/casa_functions.py
+++ b/casa_formats_io/casa_low_level_io/casa_functions.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .table import Table
+from .table import CASATable
 from .data_managers import StandardStMan, TiledCellStMan
 
 __all__ = ['getdminfo', 'getdesc']
@@ -12,7 +12,7 @@ def getdminfo(filename, endian='>'):
     with metadata about the .image file, parsed from the ``table.f0`` file.
     """
 
-    table = Table.read(filename, endian=endian)
+    table = CASATable.read(filename, endian=endian)
 
     colset = table.column_set
     dm = colset.data_managers[0]
@@ -68,7 +68,7 @@ def getdesc(filename, endian='>'):
     with metadata about the .image file, parsed from the ``table.dat`` file.
     """
 
-    table = Table.read(filename, endian=endian)
+    table = CASATable.read(filename, endian=endian)
 
     coldesc = table.desc.column_description
 

--- a/casa_formats_io/casa_low_level_io/data_managers/tiled.py
+++ b/casa_formats_io/casa_low_level_io/data_managers/tiled.py
@@ -54,7 +54,7 @@ class TiledStMan(BaseCasaObject):
         # if self.nrfile != 1:
         #     raise ValueError("Expected nrfile to be 1, got {0}".format(self.nrfile))
 
-        self.max_itsm = 0
+        self.max_tsm_index = 0
 
         for itsm in range(self.nrfile):
 
@@ -65,7 +65,7 @@ class TiledStMan(BaseCasaObject):
             if not flag:
                 continue
 
-            self.max_itsm = itsm
+            self.max_tsm_index = itsm
 
             # The following two values are unknown, but are likely relevant when there
             # are more that one field in the image.

--- a/casa_formats_io/casa_low_level_io/data_managers/tiled.py
+++ b/casa_formats_io/casa_low_level_io/data_managers/tiled.py
@@ -1,6 +1,9 @@
 import os
+from collections import defaultdict
 
 import numpy as np
+
+import dask.array as da
 
 from ..core import (check_type_and_version, BaseCasaObject, with_nbytes_prefix,
                     read_string, read_int32, read_int64, read_iposition,
@@ -51,9 +54,9 @@ class TiledStMan(BaseCasaObject):
         # if self.nrfile != 1:
         #     raise ValueError("Expected nrfile to be 1, got {0}".format(self.nrfile))
 
-        self.max_tsm_index = 0
+        self.max_itsm = 0
 
-        for tsm_index in range(self.nrfile):
+        for itsm in range(self.nrfile):
 
             # The following flag seems to control whether or not the TSM file is
             # opened by CASA, and is probably safe to ignore here.
@@ -62,7 +65,7 @@ class TiledStMan(BaseCasaObject):
             if not flag:
                 continue
 
-            self.max_tsm_index = tsm_index
+            self.max_itsm = itsm
 
             # The following two values are unknown, but are likely relevant when there
             # are more that one field in the image.
@@ -82,7 +85,7 @@ class TiledStMan(BaseCasaObject):
         self.cube_shapes = []
         self.tile_shapes = []
 
-        for tsm_index in range(self.nrfile):
+        for itsm in range(self.nrfile):
 
             unknown = read_int32(f)  # 1
 
@@ -260,28 +263,38 @@ class TiledShapeStMan(TiledStMan):
         # chunkshape defines how the chunks (array subsets) are written to disk
         chunkshape = list(self.default_tile_shape)
 
-        # TODO: for now we assume that the cubes are in the right order in
-        # self.cube_index and that self.last_row_abs is monotically increasing.
-        # This assumption might actually be ok but we should check.
+        if len(self.last_row_abs.elements) == 0:
+            return VariableShapeArrayList([])
 
-        position = {}
+        tsm_indices = np.unique(self.cube_index.elements)
 
-        arrays = []
-        for tsm_index, row_index in zip(self.cube_index.elements, self.last_row_sub.elements):
+        # Start off by reading each TSM file into a dask array
+        dask_arrays = {}
+        for itsm in tsm_indices:
+            dask_arrays[itsm] = self._read_tsm_file(filename, seqnr, coldesc,
+                                                    self.cube_shapes[itsm],
+                                                    self.tile_shapes[itsm],
+                                                    tsm_index=itsm)
 
-            if tsm_index not in position:
-                position[tsm_index] = 0
+        # Next up, we construct for each of the hypercubes an array of row indices
+        # in the final table that each hypercube row corresponds to.
 
-            subcubeshape = self.cube_shapes[tsm_index]
-            subcubeshape[-1] = (row_index + 1 - position[tsm_index])
-            subchunkshape = self.tile_shapes[tsm_index]
+        # Start off by making a master index of all rows
+        index = da.arange(self.last_row_abs.elements[-1] + 1)
 
-            arrays.append(self._read_tsm_file(filename, seqnr, coldesc, subcubeshape, subchunkshape, tsm_index=tsm_index,
-                                              offset=position[tsm_index] * np.product(subcubeshape[:-1])))
+        # Construct the index for each TSM cube
+        tsm_row_index = defaultdict(list)
+        for idx in range(len(self.cube_index.elements)):
+            start = 0 if idx == 0 else self.last_row_abs.elements[idx - 1] + 1
+            end = self.last_row_abs.elements[idx] + 1
+            tsm_row_index[self.cube_index.elements[idx]].append(index[start:end])
 
-            position[tsm_index] = row_index + 1
+        # Make each row index into a single dask array
+        for itsm in tsm_row_index:
+            tsm_row_index[itsm] = da.hstack(tsm_row_index[itsm])
 
-        return VariableShapeArrayList(arrays)
+        # Return a list of (row_index, hypercube) tuples
+        return VariableShapeArrayList([(tsm_row_index[itsm], dask_arrays[itsm]) for itsm in tsm_indices])
 
 
 class TiledColumnStMan(TiledStMan):

--- a/casa_formats_io/casa_low_level_io/table.py
+++ b/casa_formats_io/casa_low_level_io/table.py
@@ -307,7 +307,7 @@ class Table(BaseCasaObject):
 
         return table
 
-    def as_astropy_tables(self):
+    def as_astropy_table(self, data_desc_id=None):
 
         # We now loop over columns and read the relevant data from each bucket.
 
@@ -344,55 +344,54 @@ class Table(BaseCasaObject):
             else:
                 warnings.warn(f'Skipping column {colname} with data manager {dm.__class__.__name__}')
 
-        # Some columns have variable shape - in this case we split the output
-        # into several tables. We keep track of all the locations where the
-        # shape changes and later combine that into a single list.
+        # In some files (e.g. ms files) some columns can have variable shape. For now
+        # we only deal with this if DATA_DESC_ID is defined as a column in the table
+        # as it allows us to know how to extract sub-tables with constant shapes.
 
-        split = None
-        last_rows = {}
+        if 'DATA_DESC_ID' in table_columns:
 
-        for colname, data in table_columns.items():
-            if isinstance(data, VariableShapeArrayList):
-                if split is None:
-                    split = set()
-                last_rows[colname] = np.cumsum([array.shape[0] for array in data])
-                split |= set(np.cumsum([array.shape[0] for array in data]))
-
-
-        if split is None:
-            return [AstropyTable(data=ensure_mixin_columns(table_columns))]
-        else:
-            # Convert to a sorted list
-            split = sorted(split)
+            data_desc_ids = sorted(np.unique(table_columns['DATA_DESC_ID']))
 
             tables = []
 
-            start = 0
-            for end in split:
+            if data_desc_id is None:
+                if len(data_desc_ids) == 1:
+                    data_desc_id = data_desc_ids[0]
+                else:
+                    raise ValueError("There are multiple DATA_DESC_ID values present "
+                                     "in the table, select the one you need with "
+                                     "data_desc_id=<value>. Valid options are "
+                                     + "/".join([str(x) for x in data_desc_ids]))
 
-                columns_sub = OrderedDict()
-                for colname, data in table_columns.items():
-                    if isinstance(data, VariableShapeArrayList):
-                        if len(data) == 0:
-                            continue
-                        index = np.searchsorted(last_rows[colname], start, side='right')
-                        if index == 0:
-                            offset = 0
-                        else:
-                            offset = last_rows[colname][index - 1]
-                        columns_sub[colname] = data[index][start - offset:end - offset]
+            keep = table_columns['DATA_DESC_ID'] == data_desc_id
+
+            columns_sub = OrderedDict()
+            for colname, data in table_columns.items():
+                if isinstance(data, VariableShapeArrayList):
+                    if len(data) == 0:
+                        continue
+                    for row_index, array in data:
+                        matches = table_columns['DATA_DESC_ID'][row_index] == data_desc_id
+                        if np.any(matches):
+                            columns_sub[colname] = array[matches]
+                            break
                     else:
-                        columns_sub[colname] = data[start:end]
+                        columns_sub[colname] = []
+                else:
+                    columns_sub[colname] = data[keep]
 
-                tables.append(AstropyTable(data=ensure_mixin_columns(columns_sub)))
+            table = AstropyTable(data=ensure_mixin_columns(columns_sub))
+            table.meta['DATA_DESC_ID'] = data_desc_id
 
-                start = end
+            return table
 
-            # For MS files, each table will likely have a unique DATA_DESC_ID so
-            # for that special case we could have users select the required table
-            # with this, but that could happen at a higher level.
+        else:
 
-            return tables
+            for data in table_columns.values():
+                if isinstance(data, VariableShapeArrayList):
+                    raise NotImplementedError("Can't handle tables with variable shaped columns where DATA_DESC_ID does not exist")
+
+            return AstropyTable(data=ensure_mixin_columns(table_columns))
 
     @classmethod
     @with_nbytes_prefix

--- a/casa_formats_io/casa_low_level_io/table.py
+++ b/casa_formats_io/casa_low_level_io/table.py
@@ -371,6 +371,9 @@ class Table(BaseCasaObject):
                     if len(data) == 0:
                         continue
                     for row_index, array in data:
+                        # Workaround for https://github.com/dask/dask/issues/8387
+                        if len(row_index) < 32:
+                            row_index = row_index.compute()
                         matches = table_columns['DATA_DESC_ID'][row_index] == data_desc_id
                         if np.any(matches):
                             columns_sub[colname] = array[matches]

--- a/casa_formats_io/casa_low_level_io/table.py
+++ b/casa_formats_io/casa_low_level_io/table.py
@@ -265,7 +265,7 @@ def ensure_mixin_columns(columns):
     return new_columns
 
 
-class Table(BaseCasaObject):
+class CASATable(BaseCasaObject):
 
     @classmethod
     def read(cls, filename, endian='<'):

--- a/casa_formats_io/casa_low_level_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io/tests/test_casa_low_level_io.py
@@ -144,7 +144,7 @@ def test_generic_table_read(tmp_path):
     assert pformat(actual_getdminfo) == pformat(reference_getdminfo)
 
     tnew = Table.read(filename_casa, endian='<')
-    tnew.as_astropy_tables()
+    tnew.as_astropy_table()
 
 
 def test_getdesc_floatarray():
@@ -187,7 +187,7 @@ def test_logtable(tmp_path):
 
     tnew = Table.read(logtable, endian='<')
 
-    tnew.as_astropy_tables()
+    tnew.as_astropy_table()
 
 
 @pytest.mark.parametrize('tablename', ('.',
@@ -216,7 +216,7 @@ def test_ms_tables(tablename):
         pytest.xfail()
 
     t = Table.read(table_filename, endian='<')
-    tt = t.as_astropy_tables()
+    tt = [t.as_astropy_table(data_desc_id=0), t.as_astropy_table(data_desc_id=1)]
 
     if CASATOOLS_INSTALLED:
 
@@ -272,7 +272,7 @@ def test_vector_columns(tmp_path):
     tb.close()
 
     tnew = Table.read(filename_casa, endian='<')
-    t2 = tnew.as_astropy_tables()[0]
+    t2 = tnew.as_astropy_table()
 
     assert_equal(t['short'], t2['short'])
     assert_equal(t['int'], t2['int'])
@@ -303,7 +303,7 @@ def test_casadata(table_filename):
         pytest.xfail()
 
     t = Table.read(table_filename, endian='<')
-    tt = t.as_astropy_tables()[0]
+    tt = t.as_astropy_table()
 
     if CASATOOLS_INSTALLED:
 

--- a/casa_formats_io/casa_low_level_io/tests/test_casa_low_level_io.py
+++ b/casa_formats_io/casa_low_level_io/tests/test_casa_low_level_io.py
@@ -5,13 +5,13 @@ import glob
 import pytest
 import numpy as np
 from numpy.testing import assert_equal
-from astropy.table import Table as AstropyTable
+from astropy.table import Table
 from pprint import pformat
 
 from ..data_managers import TiledCellStMan
 from ..casa_functions import getdminfo, getdesc
 from ..core import EndianAwareFileHandle
-from ..table import Table
+from ..table import CASATable
 
 try:
     from casatools import table, image
@@ -95,7 +95,7 @@ def test_generic_table_read(tmp_path):
 
     N = 120
 
-    t = AstropyTable()
+    t = Table()
     t['short'] = np.arange(N, dtype=np.int16)
     t['ushort'] = np.arange(N, dtype=np.uint16)
     t['int'] = np.arange(N, dtype=np.int32)
@@ -143,8 +143,7 @@ def test_generic_table_read(tmp_path):
 
     assert pformat(actual_getdminfo) == pformat(reference_getdminfo)
 
-    tnew = Table.read(filename_casa, endian='<')
-    tnew.as_astropy_table()
+    tnew = Table.read(filename_casa)
 
 
 def test_getdesc_floatarray():
@@ -185,9 +184,7 @@ def test_logtable(tmp_path):
     assert pformat(actual_getdesc) == pformat(reference_getdesc)
     assert pformat(actual_getdminfo) == pformat(reference_getdminfo)
 
-    tnew = Table.read(logtable, endian='<')
-
-    tnew.as_astropy_table()
+    Table.read(logtable)
 
 
 @pytest.mark.parametrize('tablename', ('.',
@@ -215,8 +212,8 @@ def test_ms_tables(tablename):
     if tablename == 'SYSPOWER':
         pytest.xfail()
 
-    t = Table.read(table_filename, endian='<')
-    tt = [t.as_astropy_table(data_desc_id=0), t.as_astropy_table(data_desc_id=1)]
+    tt = [Table.read(table_filename, data_desc_id=0),
+          Table.read(table_filename, data_desc_id=1)]
 
     if CASATOOLS_INSTALLED:
 
@@ -253,15 +250,12 @@ def test_ms_tables(tablename):
 @pytest.mark.skipif('not CASATOOLS_INSTALLED')
 def test_vector_columns(tmp_path):
 
-    # NOTE: for now, this doesn't check that we can read the data - just
-    # the metadata about the table.
-
     filename_fits = str(tmp_path / 'vector.fits')
     filename_casa = str(tmp_path / 'vector.image')
 
     N = 120
 
-    t = AstropyTable()
+    t = Table()
     t['short'] = np.arange(N, dtype=np.int16).reshape((5, 4, 3, 2))
     t['int'] = np.arange(N, dtype=np.int32).reshape((5, 4, 3, 2))
     t['double'] = np.arange(N, dtype=np.float64).reshape((5, 4, 3, 2))
@@ -271,8 +265,7 @@ def test_vector_columns(tmp_path):
     tb.fromfits(filename_casa, filename_fits)
     tb.close()
 
-    tnew = Table.read(filename_casa, endian='<')
-    t2 = tnew.as_astropy_table()
+    t2 = Table.read(filename_casa)
 
     assert_equal(t['short'], t2['short'])
     assert_equal(t['int'], t2['int'])
@@ -302,8 +295,7 @@ def test_casadata(table_filename):
     if os.path.relpath(table_filename, datapath) in EXPECTED_FAILURES:
         pytest.xfail()
 
-    t = Table.read(table_filename, endian='<')
-    tt = t.as_astropy_table()
+    tt = Table.read(table_filename)
 
     if CASATOOLS_INSTALLED:
 

--- a/casa_formats_io/table_reader.py
+++ b/casa_formats_io/table_reader.py
@@ -1,12 +1,23 @@
+import os
 from astropy.table import Table
 from astropy.io import registry
 
-from casa_formats_io.casa_low_level_io.table import Table as CasaTable
+from casa_formats_io.casa_low_level_io.table import CASATable
+
+
+def identify_casa_table(origin, *args, **kwargs):
+    print(origin, args, kwargs)
+    if (isinstance(args[2], str) and
+            os.path.isdir(args[2]) and
+            os.path.exists(os.path.join(args[2], 'table.dat'))):
+        with open(os.path.join(args[2], 'table.dat'), 'rb') as f:
+            return f.read(4) == b'\xbe\xbe\xbe\xbe'
 
 
 def read_casa_table(filename, data_desc_id=None):
-    table = CasaTable.read(filename)
+    table = CASATable.read(filename)
     return table.as_astropy_table(data_desc_id=data_desc_id)
 
 
+registry.register_identifier('casa-table', Table, identify_casa_table)
 registry.register_reader('casa-table', Table, read_casa_table)

--- a/casa_formats_io/table_reader.py
+++ b/casa_formats_io/table_reader.py
@@ -1,0 +1,12 @@
+from astropy.table import Table
+from astropy.io import registry
+
+from casa_formats_io.casa_low_level_io.table import Table as CasaTable
+
+
+def read_casa_table(filename, data_desc_id=None):
+    table = CasaTable.read(filename)
+    return table.as_astropy_table(data_desc_id=data_desc_id)
+
+
+registry.register_reader('casa-table', Table, read_casa_table)

--- a/casa_formats_io/tests/test_casa_wcs.py
+++ b/casa_formats_io/tests/test_casa_wcs.py
@@ -10,7 +10,7 @@ from astropy.io import fits
 
 from numpy.testing import assert_allclose
 
-from ..casa_low_level_io import Table
+from ..casa_low_level_io.table import CASATable
 from ..casa_wcs import coordsys_to_astropy_wcs
 
 HEADER_FILENAME = os.path.join(os.path.dirname(__file__), 'data', 'header_jybeam.hdr')
@@ -46,7 +46,7 @@ def assert_header_correct(casa_filename):
 
     # Now use our coordsys_to_astropy_wcs function to create the header and compare
     # the results.
-    table = Table.read(casa_filename, endian='>')
+    table = CASATable.read(casa_filename, endian='>')
     coords = table.desc.keywords.as_dict()['coords']
     actual_wcs = coordsys_to_astropy_wcs(coords)
     actual_header = actual_wcs.to_header()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ release = '0.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['numpydoc', 'sphinx_automodapi.automodapi']
+extensions = ['numpydoc', 'sphinx_automodapi.automodapi', 'sphinx.ext.intersphinx']
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
@@ -49,13 +49,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'alabaster'
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
-
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None)}
+
+nitpicky = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,8 @@ measurement sets, you will need to also specify the ``data_desc_id=`` argument
 to :meth:`Table.read <astropy.table.Table.read>` with a valid integer
 DATA_DESC_ID value.
 
+    >>> table_3 = Table.read('my_multims.ms', format='casa-table', data_desc_id=3)
+
 Reference/API
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,23 @@ respectively.
 Finally, this package provides :func:`~casa_formats_io.coordsys_to_astropy_wcs`) which can
 be used to convert CASA WCS information to :class:`~astropy.wcs.WCS` objects.
 
+Table reader (experimental)
+---------------------------
+
+This package includes an experimental generic table reader which integrates with
+the astropy :class:`~astropy.table.Table` class. To use it, first import
+the ``casa_formats_io`` module, which registers the reader, then use the
+:meth:`Table.read <astropy.table.Table.read>` method::
+
+    >>> import casa_formats_io
+    >>> from astropy.table import Table
+    >>> table = Table.read('my_dataset.ms', format='casa-table')
+
+If the table contains a ``DATA_DESC_ID`` column, which is the case for e.g.
+measurement sets, you will need to also specify the ``data_desc_id=`` argument
+to :meth:`Table.read <astropy.table.Table.read>` with a valid integer
+DATA_DESC_ID value.
+
 Reference/API
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,14 +54,14 @@ the ``casa_formats_io`` module, which registers the reader, then use the
 
     >>> import casa_formats_io
     >>> from astropy.table import Table
-    >>> table = Table.read('my_dataset.ms', format='casa-table')
+    >>> table = Table.read('my_dataset.ms')
 
 If the table contains a ``DATA_DESC_ID`` column, which is the case for e.g.
 measurement sets, you will need to also specify the ``data_desc_id=`` argument
 to :meth:`Table.read <astropy.table.Table.read>` with a valid integer
 DATA_DESC_ID value.
 
-    >>> table_3 = Table.read('my_multims.ms', format='casa-table', data_desc_id=3)
+    >>> table_3 = Table.read('my_multims.ms', data_desc_id=3)
 
 Reference/API
 -------------


### PR DESCRIPTION
This also cleans up the API to use the standard astropy Table reader mechanism. With this, one can do e.g.:

```python
    >>> import casa_formats_io
    >>> from astropy.table import Table
    >>> table = Table.read('my_dataset.ms', format='casa-table')
```

I used the following script to check a 10Gb MS file and verified that all the data match between casatools and casa-formats-io:

```python
import numpy as np
from casatools import table
import dask.array as da
import casa_formats_io
from astropy.table import Table
from numpy.testing import assert_equal

table_filename = 'W51-IRS2_B3_uid___A001_X1296_X18f_continuum_merged_12M_selfcal.ms'

data_desc = Table.read(table_filename + '/DATA_DESCRIPTION', format='casa-table')


tb = table()
tb.open(table_filename)

for data_desc_id in range(len(data_desc)):

    print(f'DATA_DESC_ID={data_desc_id}')

    table = Table.read(table_filename, format='casa-table', data_desc_id=data_desc_id)

    sub_tb = tb.query(f'DATA_DESC_ID=={data_desc_id}')

    for colname in sub_tb.colnames():

        if colname == 'FLAG_CATEGORY':
            continue

        reference = sub_tb.getcol(colname).T
        actual = table[colname]
        if isinstance(actual, da.Array):
            actual = actual.compute()

        if reference.size == 0 and actual.size == 0:
            continue

        assert_equal(actual, reference)

        print(f' - {colname} matches')
```

There is a test failure I need to track down before we can merge, but this works fine with real-world data it seems!
