### PR TITLE
Allow low-level reader to read all data desc ids into a list of tables

### DIFF
--- a/casa_formats_io/casa_low_level_io/table.py
+++ b/casa_formats_io/casa_low_level_io/table.py
@@ -316,7 +316,19 @@ class CASATable(BaseCasaObject):
         return False
 
     def as_astropy_table(self, data_desc_id=None, include_columns=None):
-    def as_astropy_table(self, data_desc_id=None, include_columns=None, all_ddids=False):
+        """
+        Parameters
+        ----------
+        data_desc_id : 'all', None, or int
+            'all' will get all of the ddids as a list of tables
+            An integer will get the specified ddid number.
+            If there is only one ddid and `data_desc_id` is None, it will return that ddid.
+            Otherwise, an exception will be raised.
+
+        Returns
+        -------
+        table or list of tables
+        """
 
         # We now loop over columns and read the relevant data from each bucket.
 
@@ -372,19 +384,20 @@ class CASATable(BaseCasaObject):
 
             data_desc_ids = sorted(np.unique(table_columns['DATA_DESC_ID']))
 
-            if data_desc_id is None:
-                if len(data_desc_ids) == 1:
-                    data_desc_id = data_desc_ids[0]
-                    return self._read_data_descid(table_columns, data_desc_ids)
-                elif all_ddids:
-                    tables = [self._read_data_descid(table_columns, ddid)
-                              for ddid in data_desc_ids]
-                    return tables
-                else:
-                    raise ValueError("There are multiple DATA_DESC_ID values present "
-                                     "in the table, select the one you need with "
-                                     "data_desc_id=<value>. Valid options are "
-                                     + "/".join([str(x) for x in data_desc_ids]))
+            if data_desc_id is None and len(data_desc_ids) == 1:
+                data_desc_id = data_desc_ids[0]
+            elif data_desc_id == 'all':
+                tables = [self._read_data_descid(table_columns, ddid)
+                          for ddid in data_desc_ids]
+                return tables
+            elif not isinstance(data_desc_id, int):
+                raise ValueError("There are multiple DATA_DESC_ID values present "
+                                 "in the table, select the one you need with "
+                                 "data_desc_id=<value>. Valid options are "
+                                 + "/".join([str(x) for x in data_desc_ids]))
+
+            return self._read_data_descid(table_columns, data_desc_id)
+
 
         else:
 

--- a/casa_formats_io/casa_low_level_io/table.py
+++ b/casa_formats_io/casa_low_level_io/table.py
@@ -390,13 +390,15 @@ class CASATable(BaseCasaObject):
                 tables = [self._read_data_descid(table_columns, ddid)
                           for ddid in data_desc_ids]
                 return tables
-            elif not isinstance(data_desc_id, int):
+
+            try:
+                return self._read_data_descid(table_columns, data_desc_id)
+            except Exception as ex:
                 raise ValueError("There are multiple DATA_DESC_ID values present "
                                  "in the table, select the one you need with "
                                  "data_desc_id=<value>. Valid options are "
-                                 + "/".join([str(x) for x in data_desc_ids]))
-
-            return self._read_data_descid(table_columns, data_desc_id)
+                                 + "/".join([str(x) for x in data_desc_ids])
+                                 + f"  Parent exception was: {ex}")
 
 
         else:

--- a/casa_formats_io/glue_factory.py
+++ b/casa_formats_io/glue_factory.py
@@ -122,12 +122,9 @@ def ms_table_to_glue_data(table, label, polarizations):
 
     return data
 
-
-# NOTE: we set the priority to -1 here to make sure the SpectralCube loader has
-# priority for spectral cubes, but this reader *can* be used to read in the raw
-# spectral cubes.
-
-@data_factory(label='CASA Table', identifier=is_casa_table, priority=-1)
+# We set the priority here to make sure that we rank higher than the default
+# astropy Table factory.
+@data_factory(label='CASA Table', identifier=is_casa_table, priority=1)
 def read_casa_table(filename, **kwargs):
 
     casa_table = CASATable.read(filename)

--- a/casa_formats_io/tests/test_glue_factory.py
+++ b/casa_formats_io/tests/test_glue_factory.py
@@ -6,7 +6,20 @@ DATA = os.path.join(os.path.dirname(__file__), '..', 'casa_low_level_io',
 
 
 @pytest.mark.openfiles_ignore
-def test_simple():
+def test_simple_direct_factory():
+    pytest.importorskip('glue')
+    # This import is deliberately here to not automatically register
+    # the plugin for the whole test file - we want to make sure
+    # in test_simple_load_data that the plugin registration works.
+    from casa_formats_io.glue_factory import read_casa_table
+    data = read_casa_table(os.path.join(DATA, 'simple.ms'))
+    assert len(data) == 2
+    assert data[0].shape == (10, 2)
+    assert data[1].shape == (10, 4)
+
+
+@pytest.mark.openfiles_ignore
+def test_simple_load_data():
     pytest.importorskip('glue')
     from glue.main import load_plugins
     from glue.core.data_factories import load_data


### PR DESCRIPTION
@miguelcarcamov noted that one sometimes wants to read all DDIDs from a table, and looping through each DDID is quite slow because of the overhead in assembling the table metadata.

This allows the low-level reader to specify `all_ddids=True` and just loop over all the tables.

Example:
```python
from casa_formats_io.casa_low_level_io.table import CASATable
rslt = CASATable.read('HD163296_continuum.ms')
tables = rslt.as_astropy_table(all_ddids=True)
```

This is much faster than
```python
desc = Table.read('HD163296_continuum.ms/DATA_DESCRIPTION')
tables = [Table.read('HD163296_continuum.ms', data_desc_id=ii) for ii in desc['SPECTRAL_WINDOW_ID']]
```