### PR TITLE
remove a debug print statement

### DIFF
--- a/casa_formats_io/table_reader.py
+++ b/casa_formats_io/table_reader.py
@@ -6,7 +6,6 @@ from casa_formats_io.casa_low_level_io.table import CASATable
 
 
 def identify_casa_table(origin, *args, **kwargs):
-    print(origin, args, kwargs)
     if (isinstance(args[2], str) and
             os.path.isdir(args[2]) and
             os.path.exists(os.path.join(args[2], 'table.dat'))):


### PR DESCRIPTION
@astrofrog looks like this was a leftover debug statement.  It was generating messages like this when I read anything:
```
read ('/blue/adamginsburg/adamginsburg/ALMA_IMF/SPICY_ALMAIMF/SPICY_withAddOns.fits', <_io.FileIO name='/blue/adamginsburg/adamginsburg/ALMA_IMF/SPICY_ALMAIMF/SPICY_withAddOns.fits' mode='rb' closefd=True>, <_io.FileIO name='/blue/adamginsburg/adamginsburg/ALMA_IMF/SPICY_ALMAIMF/SPICY_withAddOns.fits' mode='rb' closefd=True>) {}
```