### PR TITLE
Update the wheel builds for newer python versions and drop support for py 36 and 37

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         include:
           # Build in which CASA can be installed
           - os: ubuntu-18.04
-            python-version: 3.6
+            python-version: 3.9
     steps:
     - uses: actions/checkout@v2
     - name: Set up library dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, '3.10']
         include:
           # Build in which CASA can be installed
           - os: ubuntu-18.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp38-* cp39-* cp310-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs casa_formats_io
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp36-* cp37-* cp38-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs casa_formats_io
       - uses: actions/upload-artifact@v2
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install build
         run: python -m pip install build
       - name: Build sdist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
       - name: Build wheels

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,6 @@ A small package implementing I/O for CASA data formats - see https://casa-format
 While developing this package, we made use of the https://github.com/casacore/casacore package to better understand
 the file format and have re-used some of the data class names. Therefore, since some parts of casa-formats-io may
 be considered translations of casacore into Python, we license casa-formats-io under the same LGPL license as casacore.
+
+
+casa-formats-io supports python versions >=3.8.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,8 @@ to provide:
 At this time (November 2020), only reading .image datasets is supported. Reading measurement sets
 (.ms) or writing data of any kind are not yet supported.
 
+casa-formats-io supports python versions >=3.8.
+
 Using casa-formats-io
 ---------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     astropy>=4.0
     numpy>=1.17
     dask[array]>=2.0
-python_requires = >=3.6
+python_requires = >=3.8
 
 [options.extras_require]
 test =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-oldestdeps,-devdeps,-casa}
+    py{38,39,310}-test{,-oldestdeps,-devdeps,-casa}
     build_docs
     codestyle
 requires =


### PR DESCRIPTION
This should fix #43 for pip installs.