### PR TITLE
Switch to using the limited Python API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-*
+          CIBW_SKIP: cp36-* cp37-*
+          CIBW_BUILD: cp*
           CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: pytest --pyargs casa_formats_io
       - uses: actions/upload-artifact@v2

--- a/casa_formats_io/_casa_chunking.c
+++ b/casa_formats_io/_casa_chunking.c
@@ -6,7 +6,9 @@
 #include <numpy/npy_math.h>
 
 // https://github.com/numpy/numpy/issues/16970.
-struct _typeobject {};
+struct _typeobject {
+  int foo;
+};
 
 /* Define docstrings */
 static char module_docstring[] = "Functions to help with CASA chunking";

--- a/casa_formats_io/_casa_chunking.c
+++ b/casa_formats_io/_casa_chunking.c
@@ -1,4 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define Py_LIMITED_API 0x030800f0
 
 #include <Python.h>
 #include <numpy/arrayobject.h>

--- a/casa_formats_io/_casa_chunking.c
+++ b/casa_formats_io/_casa_chunking.c
@@ -5,6 +5,9 @@
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>
 
+// https://github.com/numpy/numpy/issues/16970.
+struct _typeobject {};
+
 /* Define docstrings */
 static char module_docstring[] = "Functions to help with CASA chunking";
 static char _combine_chunks_docstring[] = "Combine multiple chunks into a single one";

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,3 +72,8 @@ exclude_lines =
 [options.entry_points]
 glue.plugins =
     casa_ms_reader = casa_formats_io.glue_factory:setup
+
+[bdist_wheel]
+py_limited_api = cp38
+
+

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ from setuptools.extension import Extension
 setup(use_scm_version={'write_to': os.path.join('casa_formats_io', 'version.py')},
       ext_modules=[Extension("casa_formats_io._casa_chunking",
                              [os.path.join('casa_formats_io', '_casa_chunking.c')],
+                             py_limited_api=True,
                              include_dirs=[numpy.get_include()])])


### PR DESCRIPTION
This should allow only one wheel to be built per platform and be forward-compatible with all future Python 3 versions (which means we don't need to release a new version of casa-formats-io just because there is a new Python version). I'll need to check the wheel build logs to make sure things are working properly.