### PR TITLE
Switch to using OpenAstronomy workflow for publishing wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,5 +8,13 @@ jobs:
     with:
       test_extras: test
       test_command: pytest --pyargs casa_formats_io
+      targets: |
+        - cp*-manylinux_i686
+        - cp*-manylinux_x86_64
+        - cp*-manylinux_aarch64
+        - cp*-macosx_x86_64
+        - cp*-macosx_arm64
+        - cp*-win32
+        - cp*-win_amd64
     secrets:
       pypi_token: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,59 +3,10 @@ name: Build and upload to PyPI
 on: [push, pull_request]
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: cp36-* cp37-*
-          CIBW_BUILD: cp*
-          CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: pytest --pyargs casa_formats_io
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-      - name: Install build
-        run: python -m pip install build
-      - name: Build sdist
-        run: python -m build --sdist --outdir dist/ .
-      - uses: actions/upload-artifact@v2
-        with:
-          path: dist/*.tar.gz
-
-  upload_pypi:
-    name: Upload to PyPI
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+  publish:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    with:
+      test_extras: test
+      test_command: pytest --pyargs casa_formats_io
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,4 +9,4 @@ jobs:
       test_extras: test
       test_command: pytest --pyargs casa_formats_io
     secrets:
-      pypi_token: ${{ secrets.pypi_token }}
+      pypi_token: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,10 @@ build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
 skip = "cp36-* cp37-*"
+test-skip = "*-macosx_arm64 *-manylinux_aarch64"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = ["setuptools",
             "oldest-supported-numpy",
             "wheel"]
 build-backend = 'setuptools.build_meta'
+
+[tool.cibuildwheel]
+skip = "cp36-* cp37-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools",
 build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
-skip = "cp36-* cp37-*"
+skip = "cp36-* cp37-* pp* *-musllinux*"
 test-skip = "*-macosx_arm64 *-manylinux_aarch64"
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
This should simplify the configuration - for now I'm explicitly listing different targets in case some don't work, will simplify further once I see what works/doesn't work.

(needs rebasing once #50 is merged)