### PR TITLE
Added CI jobs that use conda compilers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,13 @@ jobs:
       uses: codecov/codecov-action@v1.0.13
       with:
         file: ./coverage.xml
+
+  extra-tests:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        # Note that adding -conda ensures that the workflow sets up
+        # a conda environment, but does not change any of the behavior
+        # in tox.
+        - linux: py39-test-linuxgcc-conda
+        - macos: py39-test-osxclang-conda

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ passenv =
     CONDA_BUILD_SYSROOT
 setenv =
     osxclang: CC=clang-10
-    linuxgcc: CC=gcc_linux-64
+    linuxgcc: CC=x86_64-conda-linux-gnu-gcc
 changedir =
     .tmp/{envname}
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-test{,-oldestdeps,-devdeps,-casa}
+    py{38,39,310}-test{,-oldestdeps,-devdeps,-casa}{,-conda}
     build_docs
     codestyle
 requires =
@@ -19,6 +19,10 @@ passenv =
     LC_ALL
     LC_CTYPE
     ON_TRAVIS
+    CONDA_BUILD_SYSROOT
+setenv =
+    osxclang: CC=clang-10
+    linuxgcc: CC=gcc_linux-64
 changedir =
     .tmp/{envname}
 description =
@@ -37,6 +41,12 @@ deps =
     # Note that it looks like there is a casatools bug in 6.4.3.8
     # https://github.com/radio-astro-tools/casa-formats-io/issues/39
     casa-!oldestdeps: :NRAO:casatools<6.4.3.8
+conda_deps =
+    osxclang: clang_osx-64==10
+    osxclang: llvm-openmp
+    linuxgcc: gcc_linux-64
+conda_channels =
+    linuxgcc: conda-forge
 extras =
     test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
     ON_TRAVIS
     CONDA_BUILD_SYSROOT
 setenv =
-    osxclang: CC=clang-10
+    osxclang: CC=clang-10 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
     linuxgcc: CC=x86_64-conda-linux-gnu-gcc
 changedir =
     .tmp/{envname}


### PR DESCRIPTION
This re-uses an approach we developed in extension-helpers - I wonder whether issues such as https://github.com/radio-astro-tools/casa-formats-io/issues/48 are due to our C code not compiling properly with conda compilers - and in any case it's not a bad idea to have these jobs.

I do want to try and switch over the rest of the tests to the OA workflow but that's not urgent.