### PR TITLE
Build against Numpy 2.0.0rc1 for Python>=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 requires = ["setuptools",
             "setuptools_scm",
             "oldest-supported-numpy;python_version<'3.9'",
-            "numpy>=1.25,<2;python_version>='3.9'",
-            "wheel"]
+            "numpy>=2.0.0rc1;python_version>='3.9'"]
 build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]


### PR DESCRIPTION
We need to do this and release new wheels to be compatible with the upcoming Numpy 2.0