### PR TITLE
Bump minimum required Python version to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,21 +9,20 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: py38-test-casa-oldestdeps
-        - linux: py38-test-casa
-        - linux: py39-test
-        - linux: py310-test
-        - linux: py311-test-devdeps
+        - linux: py39-test-oldestdeps
+        - linux: py310-test-casa
+        - linux: py311-test
+        - linux: py312-test-devdeps
 
-        - macos: py38-test-casa
         - macos: py39-test
-        - macos: py310-test
-        - macos: py311-test-devdeps
+        - macos: py310-test-casa
+        - macos: py311-test
+        - macos: py312-test-devdeps
 
-        - windows: py38-test
         - windows: py39-test
         - windows: py310-test
-        - windows: py311-test-devdeps
+        - windows: py311-test
+        - windows: py312-test-devdeps
 
         # NOTE: the tests below are disabled for now until tox-conda is compatible with tox 4
 

--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,4 @@ the file format and have re-used some of the data class names. Therefore, since 
 be considered translations of casacore into Python, we license casa-formats-io under the same LGPL license as casacore.
 
 
-casa-formats-io supports python versions >=3.8.
+casa-formats-io supports python versions >=3.9.

--- a/casa_formats_io/casa_low_level_io/casa_functions.py
+++ b/casa_formats_io/casa_low_level_io/casa_functions.py
@@ -24,7 +24,7 @@ def getdminfo(filename, endian='>'):
 
     if isinstance(dm, StandardStMan):
 
-        dminfo['COLUMNS'] = np.array(sorted(col.name for col in colset.columns), '<U16')
+        dminfo['COLUMNS'] = np.array(sorted(col.name for col in colset.columns), 'U')
         dminfo['NAME'] = dm.name
         dminfo['SEQNR'] = 0
         dminfo['TYPE'] = 'StandardStMan'

--- a/casa_formats_io/casa_low_level_io/core.py
+++ b/casa_formats_io/casa_low_level_io/core.py
@@ -158,7 +158,7 @@ ARRAY_ITEM_READERS = {
     'float': ('float', read_float32, np.float32),
     'double': ('double', read_float64, np.float64),
     'dcomplex': ('void', read_complex128, np.complex128),
-    'string': ('String', read_string, '<U16'),
+    'string': ('String', read_string, 'U'),
     'int': ('Int', read_int32, int),
     'uint': ('uInt', read_int32, int)
 }
@@ -172,7 +172,7 @@ TO_DTYPE['float'] = 'f4'
 TO_DTYPE['int'] = 'i4'
 TO_DTYPE['uint'] = 'u4'
 TO_DTYPE['short'] = 'i2'
-TO_DTYPE['string'] = '<U16'
+TO_DTYPE['string'] = 'U'
 TO_DTYPE['bool'] = 'bool'
 TO_DTYPE['record'] = 'O'
 
@@ -192,10 +192,6 @@ def read_as_numpy_array(f, value_type, nelem, shape=None, length_modifier=0):
     if value_type == 'string':
         array = np.array([read_string(f, length_modifier=length_modifier)
                           for i in range(nelem)])
-        if nelem > 0:
-            # HACK: only needed for getdesc comparisons
-            if max([len(s) for s in array]) < 16:
-                array = array.astype('<U16')
     elif value_type == 'bool':
         length = int(np.ceil(nelem / 8)) * 8
         array = np.unpackbits(np.frombuffer(f.read(length), dtype='uint8'),

--- a/casa_formats_io/casa_low_level_io/table.py
+++ b/casa_formats_io/casa_low_level_io/table.py
@@ -231,17 +231,17 @@ class TableRecord(BaseCasaObject):
             elif rectype == 'table':
                 self.values[name] = 'Table: ' + os.path.abspath(os.path.join(f.original_filename, read_string(f)))
             elif rectype == 'arrayint':
-                self.values[name] = read_array(f, 'int')
+                self.values[name] = read_array(f, 'int').astype('<i4')
             elif rectype == 'arrayuint':
-                self.values[name] = read_array(f, 'uint')
+                self.values[name] = read_array(f, 'uint').astype('<u4')
             elif rectype == 'arrayfloat':
-                self.values[name] = read_array(f, 'float')
+                self.values[name] = read_array(f, 'float').astype('<f4')
             elif rectype == 'arraydouble':
-                self.values[name] = read_array(f, 'double')
+                self.values[name] = read_array(f, 'double').astype('<f8')
             elif rectype == 'arraycomplex':
-                self.values[name] = read_array(f, 'complex')
+                self.values[name] = read_array(f, 'complex').astype('<c8')
             elif rectype == 'arraydcomplex':
-                self.values[name] = read_array(f, 'dcomplex')
+                self.values[name] = read_array(f, 'dcomplex').astype('<c16')
             elif rectype == 'arraystr':
                 self.values[name] = read_array(f, 'string')
             elif rectype == 'record':

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ to provide:
 At this time (November 2020), only reading .image datasets is supported. Reading measurement sets
 (.ms) or writing data of any kind are not yet supported.
 
-casa-formats-io supports python versions >=3.8.
+casa-formats-io supports python versions >=3.9.
 
 Using casa-formats-io
 ---------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ docs =
 casa =
     # Note that it looks like there is a casatools bug in 6.4.3.8
     # https://github.com/radio-astro-tools/casa-formats-io/issues/39
-    casatools>=6.2.0.124,<6.4.3.8
+    casatools>=6.2.0.12
 
 [options.package_data]
 casa_formats_io.tests = data/*, data/*/*, data/*/*/*, data/*/*/*/*
@@ -38,8 +38,6 @@ casa_formats_io.casa_low_level_io.tests = data/*, data/*/*, data/*/*/*, data/*/*
 minversion = 3.0
 norecursedirs = build docs/_build
 doctest_plus = enabled
-filterwarnings =
-    error::ResourceWarning
 
 [coverage:run]
 omit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ casa_formats_io.casa_low_level_io.tests = data/*, data/*/*, data/*/*/*, data/*/*
 [tool:pytest]
 minversion = 3.0
 norecursedirs = build docs/_build
-doctest_plus = enabled
 
 [coverage:run]
 omit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     astropy>=4.0
     numpy>=1.21
     dask[array]>=2.0
-python_requires = >=3.8
+python_requires = >=3.9
 
 [options.extras_require]
 test =
@@ -79,4 +79,4 @@ glue.plugins =
     casa_ms_reader = casa_formats_io.glue_factory:setup
 
 [bdist_wheel]
-py_limited_api = cp38
+py_limited_api = cp39

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-test{,-oldestdeps,-devdeps,-casa}{,-conda}
+    py{39,310,311,312}-test{,-oldestdeps,-devdeps,-casa}{,-conda}
     build_docs
     codestyle
 requires =


### PR DESCRIPTION
Similar to https://github.com/astrofrog/fast-histogram/pull/87 - we need to bump the minimum required version of Python to 3.9 to be able to build limited API wheels with Python 3.9 that will be Numpy 2.0-compatible.

Fixes https://github.com/radio-astro-tools/casa-formats-io/issues/39