### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: ".github/workflows" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,26 +2,46 @@ name: Run tests
 
 on:
   push:
+    branches:
+    - main
+    tags:
+    - '*'
   pull_request:
+  schedule:
+    # run every Tuesday at 5am UTC
+    - cron: '0 5 * * 2'
+  workflow_dispatch:
 
 jobs:
   tests:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       envs: |
+        - linux: build_docs
+
         - linux: py39-test-oldestdeps
         - linux: py310-test-casa
+        - linux: py312-test-casa
+        - linux: py313-test-casa
         - linux: py311-test
+        - linux: py312-test
+        - linux: py313-test
         - linux: py312-test-devdeps
 
         - macos: py39-test
         - macos: py310-test-casa
+        - macos: py312-test-casa
+        - macos: py313-test-casa
         - macos: py311-test
+        - macos: py312-test
+        - macos: py313-test
         - macos: py312-test-devdeps
 
         - windows: py39-test
         - windows: py310-test
         - windows: py311-test
+        - windows: py312-test
+        - windows: py313-test
         - windows: py312-test-devdeps
 
         # NOTE: the tests below are disabled for now until tox-conda is compatible with tox 4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ jobs:
   publish:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     with:
+      env: |
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
       test_extras: test
       test_command: pytest --pyargs casa_formats_io
       targets: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,9 @@ jobs:
       targets: |
         - cp*-manylinux_x86_64
         - cp*-manylinux_aarch64
-        - pp39-manylinux_x86_64
         - cp*-macosx_x86_64
         - cp*-macosx_arm64
-        - pp39-macosx_x86_64
         - cp*-win32
         - cp*-win_amd64
-        - pp39-win_amd64
     secrets:
       pypi_token: ${{ secrets.pypi_password }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,11 +3,17 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3"
+    python: "3.12"
 
+# Install regular dependencies.
 python:
   install:
     - method: pip
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+  configuration: docs/conf.py
+  builder: html
+  fail_on_warning: true

--- a/casa_config_template.py
+++ b/casa_config_template.py
@@ -1,0 +1,6 @@
+import os
+here = os.path.dirname(os.path.abspath('.'))
+datapath=[os.path.join(here, '.casa', 'data')]
+measurespath=datapath[0]
+measures_auto_update=True
+data_auto_update=True

--- a/casa_formats_io/casa_low_level_io/core.py
+++ b/casa_formats_io/casa_low_level_io/core.py
@@ -115,7 +115,7 @@ def read_int16(f):
 
 
 def read_int32(f):
-    return np.int32(struct.unpack(f.endian + 'i', f.read(4))[0])
+    return np.int32(struct.unpack(f.endian + 'i', f.read(4))[0]).item()
 
 
 def bytes_to_int32(bytes, endian):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Using casa-formats-io
 ---------------------
 
 To construct a dask array backed by a .image dataset, use the
-:func:`~casa_io_formats.image_to_dask` function::
+:func:`~casa_formats_io.image_to_dask` function::
 
     >>> from casa_formats_io.casa_dask import image_to_dask
     >>> dask_array = image_to_dask('my_dataset.image/')
@@ -31,11 +31,11 @@ To construct a dask array backed by a .image dataset, use the
 
 Note that rather than use the native CASA chunk size as the size of dask chunks,
 which is extremely inefficient for large datasets (for which there may be a
-million CASA chunks or more), the :func:`casa_io_formats.image_to_dask` function will
+million CASA chunks or more), the :func:`casa_formats_io.image_to_dask` function will
 automatically join neighbouring chunks together on-the-fly which then provides
 significantly better performance.
 
-In addition to :func:`~casa_io_formats.image_to_dask`, this package
+In addition to :func:`~casa_formats_io.image_to_dask`, this package
 implements :func:`~casa_formats_io.getdesc` and :func:`~casa_formats_io.getdminfo`
 which aim to return the same results as CASA's
 `getdesc <https://casadocs.readthedocs.io/en/stable/api/tt/stubs.tools.table.html#stubs.tools.table.getdesc>`__
@@ -52,7 +52,7 @@ Table reader (experimental)
 This package includes an experimental generic table reader which integrates with
 the astropy :class:`~astropy.table.Table` class. To use it, first import
 the ``casa_formats_io`` module, which registers the reader, then use the
-:meth:`Table.read <astropy.table.Table.read>` method::
+:obj:`Table.read <astropy.table.Table.read>` method::
 
     >>> import casa_formats_io
     >>> from astropy.table import Table
@@ -60,7 +60,7 @@ the ``casa_formats_io`` module, which registers the reader, then use the
 
 If the table contains a ``DATA_DESC_ID`` column, which is the case for e.g.
 measurement sets, you will need to also specify the ``data_desc_id=`` argument
-to :meth:`Table.read <astropy.table.Table.read>` with a valid integer
+to :obj:`Table.read <astropy.table.Table.read>` with a valid integer
 DATA_DESC_ID value.
 
     >>> table_3 = Table.read('my_multims.ms', data_desc_id=3)

--- a/tox.ini
+++ b/tox.ini
@@ -44,10 +44,14 @@ extras =
     test
     casa: casa
 commands =
-    python --version
-    pip freeze
-    pytest --pyargs casa_formats_io {toxinidir}/docs --cov casa_formats_io --cov-config={toxinidir}/setup.cfg {posargs}
-    coverage xml -o {toxinidir}/coverage.xml
+    casa: mkdir -p .casa/data
+    casa: cp {toxinidir}/casa_config_template.py config.py
+    casa: python -m casaconfig --update-all
+    casa: python -m casaconfig --current-data
+    {list_dependencies_command}
+    !cov: pytest --pyargs casa_formats_io {toxinidir}/docs {posargs}
+    cov: pytest --pyargs casa_formats_io {toxinidir}/docs --cov casa_formats_io --cov-config={toxinidir}/pyproject.toml {posargs}
+    cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:build_docs]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
     casa: python -m casaconfig --current-data
     {list_dependencies_command}
     !cov: pytest --pyargs casa_formats_io {toxinidir}/docs {posargs}
-    cov: pytest --pyargs casa_formats_io {toxinidir}/docs --cov casa_formats_io --cov-config={toxinidir}/pyproject.toml {posargs}
+    cov: pytest --pyargs casa_formats_io {toxinidir}/docs --cov casa_formats_io --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:build_docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{,-oldestdeps,-devdeps,-casa}{,-conda}
+    py{39,310,311,312,313}-test{,-oldestdeps,-devdeps,-casa}{,-conda}
     build_docs
     codestyle
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,9 @@ commands =
     !cov: pytest --pyargs casa_formats_io {toxinidir}/docs {posargs}
     cov: pytest --pyargs casa_formats_io {toxinidir}/docs --cov casa_formats_io --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
+allowlist_externals =
+    mkdir
+    cp
 
 [testenv:build_docs]
 changedir =


### PR DESCRIPTION
I started hitting install issues with casa-formats-io that seems like they're related to casa-formats-io wheels being built with an old numpy version.

This is to update the CI, check things are working, and after the PR is merged tag and release.