### PR TITLE
Fix stale and self-contradictory docs content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.3.1 (unreleased)
+------------------
 
 - Fixed ``read_int32`` to return a native Python int rather than a numpy
   scalar. [#66]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+- Fixed ``read_int32`` to return a native Python int rather than a numpy
+  scalar. [#66]
+
 0.3.0 (2024-04-17)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,16 +14,16 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from datetime import datetime
+from importlib import metadata
+
+release = metadata.version('casa-formats-io')
 
 # -- Project information -----------------------------------------------------
 
 project = 'casa-formats-io'
-copyright = '2020, Thomas Robitaille, Adam Ginsburg, and Eric Koch'
+copyright = f'2020-{datetime.now().year}, Thomas Robitaille, Adam Ginsburg, and Eric Koch'
 author = 'Thomas Robitaille, Adam Ginsburg, and Eric Koch'
-
-# The full version, including alpha/beta/rc tags
-release = '0.0'
-
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,17 +5,17 @@ Scope
 -----
 
 The **casa-formats-io** package is a small package which implements
-functionality to read data stored in CASA formats (such as .image datasets).
-This implementation is independent of and does not use `casacore
-<https://casacore.github.io/casacore/>`_. The motivation for this package is
-to provide:
+functionality to read data stored in CASA formats (such as .image datasets
+and measurement sets). This implementation is independent of and does not
+use `casacore <https://casacore.github.io/casacore/>`_. The motivation for
+this package is to provide:
 
 * Efficient data access via `dask <https://dask.org/>`_ arrays
 * Cross-platform data access, supporting Linux, MacOS X and Windows
-* Data access with all modern Python versions, from 3.6 to the latest Python version
+* Data access with all supported Python versions
 
-At this time (November 2020), only reading .image datasets is supported. Reading measurement sets
-(.ms) or writing data of any kind are not yet supported.
+Reading .image datasets and CASA tables (including measurement sets) is
+supported. Writing data of any kind is not yet supported.
 
 casa-formats-io supports python versions >=3.9.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ this package is to provide:
 
 * Efficient data access via `dask <https://dask.org/>`_ arrays
 * Cross-platform data access, supporting Linux, MacOS X and Windows
-* Data access with all supported Python versions
+* Data access with all supported Python versions (>=3.9)
 
 Reading .image datasets and CASA tables (including measurement sets) is
 supported. Writing data of any kind is not yet supported.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,3 +71,9 @@ Reference/API
 .. automodapi:: casa_formats_io
    :no-inheritance-diagram:
    :inherited-members:
+
+radio-astro-tools
+-----------------
+
+This package is part of the radio-astro-tools project. See
+`radio-astro-tools <https://radio-astro-tools.github.io/>`_ for more information.


### PR DESCRIPTION
## Summary
- `docs/index.rst` claimed Python 3.6+ support in one bullet and `>=3.9` two lines later — dropped the stale bullet.
- `docs/index.rst` still said (as of "November 2020") that only `.image` datasets could be read and that measurement sets were unsupported, directly contradicting the "Table reader" section further down the same page, which has documented `.ms`/table reading since v0.2 (2022).
- `docs/conf.py` hardcoded `release = '0.0'` and `copyright = '2020'` instead of reflecting the installed package version / current year — now uses `importlib.metadata.version()` (matches the pattern used in sibling packages `spectral-cube`/`radio_beam`) and a running copyright year.
- Added a `CHANGES.rst` "Unreleased" entry for the `read_int32` native-type fix (#66), which was merged since 0.3.0 but never logged.

## Test plan
- [x] Verified `importlib.metadata.version('casa-formats-io')` resolves correctly without importing the compiled extension.
- [x] `tox -e build_docs` (not run locally — Sphinx toolchain not installed in this environment)