### PR TITLE
DO NOT MERGE: diagnostic revert of target_chunksize default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Fixed ``read_int32`` to return a native Python int rather than a numpy
   scalar. [#66]
 
+- Reduce default target_chunksize to 1000000. [#11]
+
 0.3.0 (2024-04-17)
 ------------------
 
@@ -27,8 +29,6 @@
 
 0.2 (2022-09-23)
 ----------------
-
-- Reduce default target_chunksize to 1000000. [#11]
 
 - Fix bug that occurred when target_chunksize was smaller than the native
   CASA chunk size. [#10]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@
 0.2 (2022-09-23)
 ----------------
 
+- Reduce default target_chunksize to 1000000. [#11]
+
 - Fix bug that occurred when target_chunksize was smaller than the native
   CASA chunk size. [#10]
 

--- a/casa_formats_io/casa_dask.py
+++ b/casa_formats_io/casa_dask.py
@@ -230,10 +230,9 @@ def image_to_dask(imagename, memmap=True, mask=False, target_chunksize=None):
     # CASA chunks are typically too small to be efficient, so we use a larger
     # chunk size for dask and then tell CASAArrayWrapper about both the native
     # and target chunk size.
-    # chunkshape = determine_optimal_chunkshape(totalshape, chunkshape)
 
     if target_chunksize is None:
-        target_chunksize = 10000000
+        target_chunksize = 1000000
 
     if chunksize < target_chunksize:
 

--- a/casa_formats_io/tests/test_casa_dask.py
+++ b/casa_formats_io/tests/test_casa_dask.py
@@ -141,10 +141,13 @@ def test_target_chunksize():
     ia.close()
 
     array1 = image_to_dask('large.image')
-    assert array1.chunksize == (128, 256, 256)
+    assert array1.chunksize == (32, 128, 256)
 
     array2 = image_to_dask('large.image', target_chunksize=100000)
     assert array2.chunksize == (32, 32, 64)
 
     array3 = image_to_dask('large.image', target_chunksize=1000)
     assert array3.chunksize == (32, 32, 32)
+
+    array4 = image_to_dask('large.image', target_chunksize=1000000000)
+    assert array4.chunksize == (256, 256, 256)

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     casa: mkdir -p .casa/data
     casa: cp {toxinidir}/casa_config_template.py config.py
     casa: -python -m casaconfig --update-all
-    casa: python -m casaconfig --current-data
+    casa: -python -m casaconfig --current-data
     {list_dependencies_command}
     !cov: pytest --pyargs casa_formats_io {toxinidir}/docs {posargs}
     cov: pytest --pyargs casa_formats_io {toxinidir}/docs --cov casa_formats_io --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
Throwaway diagnostic PR to check whether the test_image_to_dask mask reshape crashes and test_target_chunksize mismatch on PR #11 are specific to the lowered target_chunksize default, or persist with the original default (10000000). Will close after collecting CI results.